### PR TITLE
fix: 토큰 만료 시 로그인 유지가 안되는 이슈 해결

### DIFF
--- a/app/src/main/java/com/motgolla/common/storage/TokenInterceptor.kt
+++ b/app/src/main/java/com/motgolla/common/storage/TokenInterceptor.kt
@@ -39,10 +39,15 @@ class TokenInterceptor(
             val reissueResponse = client.newCall(reissueRequest).execute()
             // 재발급 성공한 경우
             if (reissueResponse.isSuccessful) {
+                Log.d("TokenInterceptor", "액세스 토큰 재발급 성공")
                 val gson = com.google.gson.Gson()
                 val newToken = gson.fromJson(reissueResponse.body?.charStream(), TokenResponse::class.java)
                 // 토큰 저장
-                TokenStorage.save(context, newToken)
+                val mergedToken = TokenResponse(
+                    accessToken = newToken.accessToken,
+                    refreshToken = tokenResponse.refreshToken
+                )
+                TokenStorage.save(context, mergedToken)
                 // 재요청
                 val newRequest = original.newBuilder()
                     .addHeader("Authorization", "Bearer ${newToken.accessToken}")


### PR DESCRIPTION
## #️⃣ Issue Number

#36 

## 📝 요약(Summary)

액세스 토큰 만료 시 재발급 후 인증이 안되는 이슈 해결
- 로그인, 회원 가입과 달리 재발급 api는 accessToken만 반환함(리프레쉬 토큰은 재발급x)
- SharedReferences에 저장된 기존 리프레쉬 토큰을 덮어쓰면서 null이 되는 문제 발견
- 기존 리프레쉬 토큰을 덮어쓰지 않도록 해결

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
